### PR TITLE
🎁 Finalize `#split_ocr_thumbnail`

### DIFF
--- a/awslambda/spec/handler_spec.rb
+++ b/awslambda/spec/handler_spec.rb
@@ -72,4 +72,20 @@ describe "handler" do
       expect(response[:statusCode]).to eq 200
     end
   end
+
+  describe "#split_ocr_thumbnail" do
+    it "splits the pdf into its pages and enqueues that many ocr and thumbnail jobs" do
+      event_json = Fixtures.event_json_for({ Fixtures.file_location_for("minimal-2-page.pdf") => [
+                                               "s3://s3.com/{{dir_parts[-1..-1]}}/{{ filename }}"] })
+      response = split_ocr_thumbnail(event: event_json, context: {}, env: { 'S3_BUCKET_NAME' => 'bucket', 'OCR_QUEUE_URL' => 'sqs://ocr', 'THUMBNAIL_QUEUE_URL' => 'sqs://thumbnail' })
+      expect(response[:body]).to eq [
+        "s3://s3.com/pages/minimal-2-page-1.tiff",
+        "s3://s3.com/pages/minimal-2-page-2.tiff",
+        "sqs://ocr/pages/minimal-2-page-1.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
+        "sqs://ocr/pages/minimal-2-page-2.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
+        "sqs://thumbnail/pages/minimal-2-page-1.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg",
+        "sqs://thumbnail/pages/minimal-2-page-2.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg"
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This commit fleshes out the `#split_ocr_thumbnail` method, which enqueues three jobs, split pdf to its pages, ocr each page, and creates a thumbnail for each page.  We also refactor this method and the #ocr method to DRY up the code.

Co-author: @jeremyf 