### PR TITLE
☑️: add spec for #ocr handler method

### DIFF
--- a/awslambda/handler.rb
+++ b/awslambda/handler.rb
@@ -55,13 +55,13 @@ def split_ocr_thumbnail(event:, context:, env: ENV)
   end
 end
 
-def ocr(event:, context:)
+def ocr(event:, context:, env: ENV)
   handle(generator: DerivativeRodeo::Generators::HocrGenerator, event: event, context: context) do |output_uris|
-    s3_url = s3_name_to_url(bucket_name: ENV['S3_BUCKET_NAME'])
+    s3_url = s3_name_to_url(bucket_name: env['S3_BUCKET_NAME'])
     output_location_templates = [
-      queue_url_to_rodeo_url(queue_url: ENV['WORD_COORDINATES_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::WordCoordinatesGenerator.output_extension}"),
-      queue_url_to_rodeo_url(queue_url: ENV['PLAIN_TEXT_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::PlainTextGenerator.output_extension}"),
-      queue_url_to_rodeo_url(queue_url: ENV['ALTO_XML_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::AltoGenerator.output_extension}"),
+      queue_url_to_rodeo_url(queue_url: env['WORD_COORDINATES_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::WordCoordinatesGenerator.output_extension}"),
+      queue_url_to_rodeo_url(queue_url: env['PLAIN_TEXT_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::PlainTextGenerator.output_extension}"),
+      queue_url_to_rodeo_url(queue_url: env['ALTO_XML_QUEUE_URL'], s3_url_domain: s3_url, template_tail: "{{dir_parts[-1..-1]}}/{{ basename }}.#{DerivativeRodeo::Generators::AltoGenerator.output_extension}"),
     ]
     send_to_locations(tmp_uris: output_uris, output_location_templates: output_location_templates)
   end

--- a/awslambda/spec/handler_spec.rb
+++ b/awslambda/spec/handler_spec.rb
@@ -2,7 +2,6 @@
 
 require_relative '../handler'
 require 'byebug'
-require 'pry-byebug'
 
 require 'spec_support/aws_s3_faux_bucket'
 require 'spec_support/aws_sqs_faux_client'
@@ -76,6 +75,7 @@ describe 'handler' do
                                            ] })
       response = split_ocr_thumbnail(event: event_json, context: {},
                                      env: { 'S3_BUCKET_NAME' => 'bucket', 'OCR_QUEUE_URL' => 'sqs://ocr', 'THUMBNAIL_QUEUE_URL' => 'sqs://thumbnail' })
+      # TODO: This spec will break once config for the region is updated in #s3_name_to_url of handler.rb to address the double dots.
       expect(response[:body]).to eq [
         's3://s3.com/pages/minimal-2-page-1.tiff',
         's3://s3.com/pages/minimal-2-page-2.tiff',
@@ -98,7 +98,9 @@ describe 'handler' do
                        'PLAIN_TEXT_QUEUE_URL' => 'sqs://text',
                        'ALTO_XML_QUEUE_URL' => 'sqs://alto'
                      })
+      # TODO: This spec will break once config for the region is updated in #s3_name_to_url of handler.rb to address the double dots.
       expect(response[:body]).to eq [
+        "s3://s3.com/123/ocr_color.tiff",
         "sqs://word_coords/123/ocr_color.coordinates.json?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.coordinates.json",
         "sqs://text/123/ocr_color.plain_text.txt?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.plain_text.txt",
         "sqs://alto/123/ocr_color.alto.xml?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.alto.xml"

--- a/awslambda/spec/handler_spec.rb
+++ b/awslambda/spec/handler_spec.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require_relative '../handler'
 require 'byebug'
+require 'pry-byebug'
 
-require "spec_support/aws_s3_faux_bucket"
-require "spec_support/aws_sqs_faux_client"
+require 'spec_support/aws_s3_faux_bucket'
+require 'spec_support/aws_sqs_faux_client'
 
 module Fixtures
   ##
@@ -28,7 +31,7 @@ module Fixtures
   end
 end
 
-describe "handler" do
+describe 'handler' do
   before do
     DerivativeRodeo::StorageLocations::S3Location.use_actual_s3_bucket = false
     DerivativeRodeo::StorageLocations::SqsLocation.use_real_sqs = false
@@ -45,15 +48,15 @@ describe "handler" do
 
   describe '#copy' do
     it 'processes each key/value pair, copying the key to each of the given values' do
-      s3_host_name = "space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com"
-      event_json = Fixtures.event_json_for({ Fixtures.file_location_for("minimal-2-page.pdf") => [
-                                                "s3://#{s3_host_name}/{{dir_parts[-1..-1]}}/{{ filename }}",
-                                                "sqs://us-west-2.amazonaws.com/559021623471/space-stone-dev-split-ocr-thumbnail/{{dir_parts[-1..-1]}}/{{ filename }}?template=s3://space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ filename }}"]
-                                             },{
-                                               Fixtures.file_location_for("minimal-2-page.txt") => [
-                                                 "s3://#{s3_host_name}/{{dir_parts[-1..-1]}}/minimal-2-page.pdf.txt"
-                                               ]
-                                             })
+      s3_host_name = 'space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com'
+      event_json = Fixtures.event_json_for({ Fixtures.file_location_for('minimal-2-page.pdf') => [
+                                             "s3://#{s3_host_name}/{{dir_parts[-1..-1]}}/{{ filename }}",
+                                             'sqs://us-west-2.amazonaws.com/559021623471/space-stone-dev-split-ocr-thumbnail/{{dir_parts[-1..-1]}}/{{ filename }}?template=s3://space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ filename }}'
+                                           ] }, {
+                                             Fixtures.file_location_for('minimal-2-page.txt') => [
+                                               "s3://#{s3_host_name}/{{dir_parts[-1..-1]}}/minimal-2-page.pdf.txt"
+                                             ]
+                                           })
       response = copy(event: event_json, context: {})
 
       # TODO: as of <2023-05-31 Wed> we cannot peak into the configured faux bucket; because that
@@ -61,31 +64,50 @@ describe "handler" do
       # expose directly).
       expect(response[:body].size).to eq(3)
       expect(response[:body]).to match_array(["s3://#{s3_host_name}/files/minimal-2-page.pdf",
-                                              "sqs://us-west-2.amazonaws.com/559021623471/space-stone-dev-split-ocr-thumbnail/files/minimal-2-page.pdf?template=s3://space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ filename }}",
+                                              'sqs://us-west-2.amazonaws.com/559021623471/space-stone-dev-split-ocr-thumbnail/files/minimal-2-page.pdf?template=s3://space-stone-dev-preprocessedbucketf21466dd-bxjjlz4251re.s3.us-west-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ filename }}',
                                               "s3://#{s3_host_name}/files/minimal-2-page.pdf.txt"])
     end
   end
 
-  describe '#ocr' do
-    xit 'when success' do
-      response = ocr(event: {}, context: {})
-      expect(response[:statusCode]).to eq 200
+  describe '#split_ocr_thumbnail' do
+    it 'splits the pdf into its pages and enqueues that many ocr and thumbnail jobs' do
+      event_json = Fixtures.event_json_for({ Fixtures.file_location_for('minimal-2-page.pdf') => [
+                                             's3://s3.com/{{dir_parts[-1..-1]}}/{{ filename }}'
+                                           ] })
+      response = split_ocr_thumbnail(event: event_json, context: {},
+                                     env: { 'S3_BUCKET_NAME' => 'bucket', 'OCR_QUEUE_URL' => 'sqs://ocr', 'THUMBNAIL_QUEUE_URL' => 'sqs://thumbnail' })
+      expect(response[:body]).to eq [
+        's3://s3.com/pages/minimal-2-page-1.tiff',
+        's3://s3.com/pages/minimal-2-page-2.tiff',
+        'sqs://ocr/pages/minimal-2-page-1.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr',
+        'sqs://ocr/pages/minimal-2-page-2.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr',
+        'sqs://thumbnail/pages/minimal-2-page-1.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg',
+        'sqs://thumbnail/pages/minimal-2-page-2.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg'
+      ]
     end
   end
 
-  describe "#split_ocr_thumbnail" do
-    it "splits the pdf into its pages and enqueues that many ocr and thumbnail jobs" do
-      event_json = Fixtures.event_json_for({ Fixtures.file_location_for("minimal-2-page.pdf") => [
-                                               "s3://s3.com/{{dir_parts[-1..-1]}}/{{ filename }}"] })
-      response = split_ocr_thumbnail(event: event_json, context: {}, env: { 'S3_BUCKET_NAME' => 'bucket', 'OCR_QUEUE_URL' => 'sqs://ocr', 'THUMBNAIL_QUEUE_URL' => 'sqs://thumbnail' })
+  describe '#ocr' do
+    it 'will enqueue three jobs: word coordinates, plain text and alto xml' do
+      event_json = Fixtures.event_json_for({ Fixtures.file_location_for('123/ocr_color.tiff') => [
+                                             's3://s3.com/{{dir_parts[-1..-1]}}/{{ filename }}'
+                                           ] })
+      response = ocr(event: event_json, context: {}, env: {
+                       'S3_BUCKET_NAME' => 'bucket',
+                       'WORD_COORDINATES_QUEUE_URL' => 'sqs://word_coords',
+                       'PLAIN_TEXT_QUEUE_URL' => 'sqs://text',
+                       'ALTO_XML_QUEUE_URL' => 'sqs://alto'
+                     })
       expect(response[:body]).to eq [
-        "s3://s3.com/pages/minimal-2-page-1.tiff",
-        "s3://s3.com/pages/minimal-2-page-2.tiff",
-        "sqs://ocr/pages/minimal-2-page-1.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
-        "sqs://ocr/pages/minimal-2-page-2.hocr?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
-        "sqs://thumbnail/pages/minimal-2-page-1.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg",
-        "sqs://thumbnail/pages/minimal-2-page-2.thumbnail.jpeg?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg"
+        "sqs://word_coords/123/ocr_color.coordinates.json?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.coordinates.json",
+        "sqs://text/123/ocr_color.plain_text.txt?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.plain_text.txt",
+        "sqs://alto/123/ocr_color.alto.xml?template=s3://bucket.s3..amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.alto.xml"
       ]
+    end
+
+    xit 'when success' do
+      response = ocr(event: {}, context: {})
+      expect(response[:statusCode]).to eq 200
     end
   end
 end

--- a/awslambda/spec/handler_spec.rb
+++ b/awslambda/spec/handler_spec.rb
@@ -79,7 +79,6 @@ describe 'handler' do
                        'PLAIN_TEXT_QUEUE_URL' => 'sqs://text',
                        'ALTO_XML_QUEUE_URL' => 'sqs://alto'
                      })
-      # TODO: This spec will break once config for the region is updated in #s3_name_to_url of handler.rb to address the double dots.
       expect(response[:body]).to eq [
         "s3://s3.com/123/ocr_color.tiff",
         "sqs://word_coords/123/ocr_color.coordinates.json?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.coordinates.json",


### PR DESCRIPTION
We are in the process of adding a spec for the #ocr handler method. It is currently failing because our expectation doesn't include a tiff file. Should it?

- Issue https://github.com/scientist-softserv/space_stone-serverless/issues/6