### PR TITLE
⚙️ Creating queues for alto, plain text, and coordinates

### DIFF
--- a/awslambda/handler.rb
+++ b/awslambda/handler.rb
@@ -79,7 +79,7 @@ def plain_text(event:, context:)
   handle(generator: DerivativeRodeo::Generators::PlainTextGenerator, event: event, context: context)
 end
 
-def alto(event:, context:)
+def alto_xml(event:, context:)
   handle(generator: DerivativeRodeo::Generators::AltoGenerator, event: event, context: context)
 end
 

--- a/awslambda/serverless.yml
+++ b/awslambda/serverless.yml
@@ -103,6 +103,10 @@ constructs:
       ephemeralStorageSize: 2560
       environment:
         RUBYOPT: '-W0'
+        S3_BUCKET_NAME: ${construct:preprocessed.bucketName}
+        WORD_COORDINATES_QUEUE_URL: ${construct:word-coordinates.queueUrl}
+        PLAIN_TEXT_QUEUE_URL: ${construct:plain-text.queueUrl}
+        ALTO_XML_QUEUE_URL: ${construct:alto-xml.queueUrl}
   thumbnail:
     type: queue
     maxRetries: 2
@@ -114,7 +118,39 @@ constructs:
       ephemeralStorageSize: 2560
       environment:
         RUBYOPT: '-W0'
-        OCR_QUEUE_URL: ${construct:ocr.queueUrl}
+  word-coordinates:
+    type: queue
+    maxRetries: 2
+    batchSize: 1
+    worker:
+      handler: handler.word_coordinates
+      memorySize: 4096 # optional, in MB, default is 1024
+      timeout: 900 # optional, in seconds, default is 6
+      ephemeralStorageSize: 2560
+      environment:
+        RUBYOPT: '-W0'
+  plain-text:
+    type: queue
+    maxRetries: 2
+    batchSize: 1
+    worker:
+      handler: handler.plain_text
+      memorySize: 4096 # optional, in MB, default is 1024
+      timeout: 900 # optional, in seconds, default is 6
+      ephemeralStorageSize: 2560
+      environment:
+        RUBYOPT: '-W0'
+  alto-xml:
+    type: queue
+    maxRetries: 2
+    batchSize: 1
+    worker:
+      handler: handler.alto_xml
+      memorySize: 4096 # optional, in MB, default is 1024
+      timeout: 900 # optional, in seconds, default is 6
+      ephemeralStorageSize: 2560
+      environment:
+        RUBYOPT: '-W0'
 
 plugins:
   - serverless-lift
@@ -127,6 +163,9 @@ custom:
       - split-ocr-thumbnailWorker
       - ocrWorker
       - thumbnailWorker
+      - word-coordinatesWorker
+      - plain-textWorker
+      - alto-xmlWorker
     use_docker: true
     docker_file: Dockerfile
     docker_image_name: ghcr.io/scientist-softserv/space_stone/awsrubylayer:latest

--- a/awslambda/spec/handler_spec.rb
+++ b/awslambda/spec/handler_spec.rb
@@ -99,14 +99,14 @@ describe 'handler' do
       event_json = Fixtures.event_json_for({ Fixtures.file_location_for("minimal-2-page.pdf") => [
                                                "s3://s3.com/{{dir_parts[-1..-1]}}/{{ filename }}"] })
       response = split_ocr_thumbnail(event: event_json, context: {}, env: { 'S3_BUCKET_NAME' => 'bucket', 'OCR_QUEUE_URL' => 'sqs://ocr', 'THUMBNAIL_QUEUE_URL' => 'sqs://thumbnail' })
-      expect(response[:body]).to eq [
-        "s3://s3.com/pages/minimal-2-page-1.tiff",
-        "s3://s3.com/pages/minimal-2-page-2.tiff",
-        "sqs://ocr/pages/minimal-2-page-1.hocr?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
-        "sqs://ocr/pages/minimal-2-page-2.hocr?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
-        "sqs://thumbnail/pages/minimal-2-page-1.thumbnail.jpeg?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg",
-        "sqs://thumbnail/pages/minimal-2-page-2.thumbnail.jpeg?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg"
-      ]
+      expect(response[:body]).to match_array([
+        "s3://s3.com/pages/minimal-2-page--page-1.tiff",
+        "s3://s3.com/pages/minimal-2-page--page-2.tiff",
+        "sqs://ocr/pages/minimal-2-page--page-1.hocr?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
+        "sqs://ocr/pages/minimal-2-page--page-2.hocr?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.hocr",
+        "sqs://thumbnail/pages/minimal-2-page--page-1.thumbnail.jpeg?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg",
+        "sqs://thumbnail/pages/minimal-2-page--page-2.thumbnail.jpeg?template=s3://bucket.s3.us-east-1.amazonaws.com/{{dir_parts[-1..-1]}}/{{ basename }}.thumbnail.jpeg"
+      ])
     end
   end
 end


### PR DESCRIPTION
Okay, this commit does a bit more, namely some tidying for consistency.

This commit has three things:

1) Fixing specs based on prior changes
2) Renaming a handler to match it's queue name
3) Adding queues for each of the new handlers

Closes #19, #7, #5

Related to:

- https://github.com/scientist-softserv/space_stone-serverless/issues/19
- https://github.com/scientist-softserv/space_stone-serverless/issues/7
- https://github.com/scientist-softserv/space_stone-serverless/issues/5

Co-authored-by: Kirk Wang <kirk.wang@scientist.com>
