### PR TITLE
Introducing more logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ docker pull ghcr.io/scientist-softserv/space_stone/awsrubylayer:latest
 AWS credentials are pulled from AWS_PROFILE. Make sure your ~/.aws/config and ~/.aws/credentials are set accordingly. See [AWS CLI docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/configure/index.html)
  for more info.
 
-### Updating Dependencies
+### Updating Submodules
 
-```bash
-git submodule update --remote
-```
+There are two submodules:
+
+- derivative_rodeo
+- serverless-ruby-layer
+
+To update the SHA, `cd` into their respective directories and pull down those changes (e.g. `git pull origin main` to get latest changes).
 
 ### When you make changes to the Dockerfile
 The deploy step is likely to be slow after changes to the Dockerfile as it rebuilds the docker image. To make sure others do not need to replicate the docker build, please push the built image afterward:

--- a/awslambda/handler.rb
+++ b/awslambda/handler.rb
@@ -8,9 +8,20 @@ Bundler.require(:default)
 require_relative './derivative_rodeo/lib/derivative_rodeo'
 
 ########################################################################################################################
+# @!group Configuration
+#
+# For debugging purposes, we want to ensure that we have lots of information regarding the
+# derivative rodeo internal processes.
+#
+# @see https://github.com/orgs/scientist-softserv/projects/43/views/3?pane=issue&itemId=30591604
+DerivativeRodeo.config do |config|
+  config.logger = Logger.new($stdout, level: Logger::INFO)
+end
+# @!endgroup Configuration
+
+########################################################################################################################
 # @!group Handlers
 # See README for more clarification
-
 
 ##
 # @param event [String] We'll convert, via {#get_event_body}, the given :event.  The results of the


### PR DESCRIPTION
## 🎁 Adding more granualar logging level for SpaceStone

92bbe3df39e059d0e5f5bbd3b379fdff935b088d

It is useful to see the inner works of decision making regarding the
derivative rodeo.  That is to say:

- "Does the file already exist at the target location?"
- "Does the file exist at the pregerenate location?"
- "Do we need to generate the at the target location?"

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

## 🎁 Updating derivative rodeo for more granular logging

d5b12ab3ddb9de20ef45391de5d7457c2e21e535

This commit contains two things:

1. Updated documentation
2. Updated submodule

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

The derivative rodeo commit changes are as follows:

- scientist-softserv/derivative_rodeo@6fd304f :: 🎁 Adding logging to generators (2023-06-12)
- scientist-softserv/derivative_rodeo@795a7d2 :: 🐛 Hacking away the .mono suffix for 2nd order derivatives (2023-06-09)
- scientist-softserv/derivative_rodeo@2502c4c :: 🐛 Ensuring we submit any stray batch messages (2023-06-09)
