### PR TITLE
⚙️ Configure PDFs to split into JPG pages

### DIFF
--- a/awslambda/handler.rb
+++ b/awslambda/handler.rb
@@ -17,6 +17,8 @@ require_relative './derivative_rodeo/lib/derivative_rodeo'
 DerivativeRodeo.config do |config|
   config.logger = Logger.new($stdout, level: Logger::INFO)
 end
+
+DerivativeRodeo::Generators::PdfSplitGenerator.output_extension = 'jpg'
 # @!endgroup Configuration
 
 ########################################################################################################################


### PR DESCRIPTION
Based on the findings of the following issue, we are wanting to split pages into JPGs.

- https://github.com/scientist-softserv/adventist-dl/issues/379

The desire for JPGs for split images is demonstrated in:

https://github.com/scientist-softserv/adventist-dl/commit/6dd0d7711d60ee4cb9eae9edd65444256fef81cc

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56
- https://github.com/scientist-softserv/adventist-dl/issues/500